### PR TITLE
add aarch64 build support and fix kernel source tree not found issue

### DIFF
--- a/build_android.sh
+++ b/build_android.sh
@@ -4,7 +4,7 @@ BUILD_PREFIX="/data/data/com.systemtap.android/stap/"
 OUTPUT_DIR="android_binaries"
 STAPIO_BIN="staprun/stapio"
 STAPRUN_BIN="staprun/staprun"
-COMPILER_PREFIX_LIST=("arm-none-linux-gnueabi" "arm-unknown-linux-gnueabi")
+COMPILER_PREFIX_LIST=("aarch64-linux-gnu" "arm-none-linux-gnueabi" "arm-unknown-linux-gnueabi")
 
 
 function checkCompiler()

--- a/tapsets.cxx
+++ b/tapsets.cxx
@@ -11478,6 +11478,19 @@ tracepoint_builder::init_dw(systemtap_session& s)
           s.kernel_source_tree = source_tree;
         }
     }
+  // find kernel_source_tree from a source link,when different from build
+  if (s.kernel_source_tree == "")
+    {
+      string source_tree = s.kernel_build_tree;
+      source_tree.append("/source");
+      if (file_exists(source_tree) &&
+          resolve_path(source_tree) != resolve_path(s.kernel_build_tree))
+        {
+          if (s.verbose > 2)
+              clog << _F("Located kernel source tree at '%s'", source_tree.c_str()) << endl;
+          s.kernel_source_tree = source_tree;
+        }
+    }
 
   // prefixes
   vector<string> glob_prefixes;


### PR DESCRIPTION
Hi,I have make a new pull request.pls review.
I meet the issue when do cross compile kernel module,without this fix,the defined tracepoint in kernel source code will be not found.
1.remove whitespace from diff.
2.there has no fix on the mainline.
